### PR TITLE
카카오 로그인

### DIFF
--- a/santa_myojeong_be/settings.py
+++ b/santa_myojeong_be/settings.py
@@ -57,9 +57,9 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     'allauth.socialaccount',
-    "allauth.socialaccount.providers.google",
     "allauth.socialaccount.providers.kakao",
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
 ]
 
 MIDDLEWARE = [
@@ -149,11 +149,10 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny'
+        'rest_framework.permissions.IsAuthenticated'
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication'
+        'dj_rest_auth.jwt_auth.JWTCookieAuthentication',
     ],
     'DEFAULT_PARSER_CLASSES': [
         'rest_framework.parsers.JSONParser',
@@ -166,6 +165,8 @@ REST_FRAMEWORK = {
 AUTH_USER_MODEL = 'user.User'
 
 SITE_ID = 1
+
+SOCIALACCOUNT_ADAPTER = 'user.adapters.KakaoAccountAdapter'
 
 REST_AUTH = {
     'USE_JWT' : True,
@@ -187,8 +188,14 @@ ACCOUNT_AUTHENTICATION_METHOD = 'email'
 REST_USE_JWT = True
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=60),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=365),
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': True,
 }
+
+
+kakao_secrets = secrets['KAKAO']
+
+KAKAO_REST_API_KEY = kakao_secrets['KAKAO_REST_API_KEY']
+KAKAO_CALLBACK_URI = kakao_secrets['KAKAO_CALLBACK_URI']

--- a/santa_myojeong_be/urls.py
+++ b/santa_myojeong_be/urls.py
@@ -15,8 +15,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('user/', include('user.urls')),
+    path('user/', include('dj_rest_auth.urls')),
+    path('user/', include('allauth.urls')),
 ]

--- a/user/adapters.py
+++ b/user/adapters.py
@@ -1,0 +1,14 @@
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.db import transaction
+
+
+class KakaoAccountAdapter(DefaultSocialAccountAdapter):
+    def save_user(self, request, sociallogin, form=None):
+        with transaction.atomic():
+            user = super().save_user(request, sociallogin, form)
+
+            oauth_data = sociallogin.account.extra_data
+            user.nickname = oauth_data['kakao_account']['profile']['nickname']
+            user.save()
+
+        return user

--- a/user/models.py
+++ b/user/models.py
@@ -46,7 +46,7 @@ class User(AbstractUser):
     last_name = None
     email = models.EmailField(unique=True, max_length=255)
 
-    nickname = models.CharField(max_length=10)
+    nickname = models.CharField(null=True, max_length=10)
     gacha_ticket = models.PositiveIntegerField(default=0)
     view_count = models.PositiveIntegerField(default=0)
     rabbit = models.IntegerField(choices=RABBITS, default=1)

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from user import views
+
+urlpatterns = [
+    path('login/', views.UserAuthView.as_view()),
+    path('login/finish/', views.KakaoLoginView.as_view()),
+]

--- a/user/views.py
+++ b/user/views.py
@@ -1,3 +1,100 @@
-from django.shortcuts import render
+from json.decoder import JSONDecodeError
 
-# Create your views here.
+import requests
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.permissions import AllowAny
+from dj_rest_auth.registration.views import SocialLoginView
+from allauth.socialaccount.providers.kakao import views as kakao_view
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
+from allauth.socialaccount.models import SocialAccount
+
+from user.models import User
+from santa_myojeong_be.settings import KAKAO_REST_API_KEY, KAKAO_CALLBACK_URI
+
+
+BASE_URL = 'http://127.0.0.1:8000/'
+
+
+class UserAuthView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        code = request.GET.get('code')
+        token = self._get_token(code)
+        email = self._get_email(token)
+
+        response = self._sign_in(email, token, code)
+
+        return response
+
+    def _get_token(self, code: str):
+        token_req = requests.get(f"https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id={KAKAO_REST_API_KEY}&redirect_uri={KAKAO_CALLBACK_URI}&code={code}")
+        token_req_json = token_req.json()
+        error = token_req_json.get("error")
+        if error is not None:
+            raise JSONDecodeError(error)
+        
+        access_token = token_req_json.get("access_token")
+
+        return access_token
+    
+    def _get_email(self, access_token: str):
+        profile_request = requests.get("https://kapi.kakao.com/v2/user/me", headers={"Authorization": f"Bearer {access_token}"})
+        profile_json = profile_request.json()
+        error = profile_json.get("error")
+        if error is not None:
+            raise JSONDecodeError(error)
+        
+        kakao_account = profile_json.get('kakao_account')
+        email = kakao_account.get('email')
+
+        return email
+    
+    def _sign_in(self, email: str, access_token: str, code: str):
+        try:
+            user = User.objects.get(email=email)
+            # 기존에 가입된 유저의 Provider가 kakao가 아니면 에러, 맞으면 로그인
+            # 다른 SNS로 가입된 유저
+            social_user = SocialAccount.objects.get(user=user)
+            if social_user is None:
+                return JsonResponse({'err_msg': 'email exists but not social user'}, status=status.HTTP_400_BAD_REQUEST)
+            if social_user.provider != 'kakao':
+                return JsonResponse({'err_msg': 'no matching social type'}, status=status.HTTP_400_BAD_REQUEST)
+            
+            # 기존에 Kakao 가입된 유저
+            response = self._get_sign_in_response(access_token, code, 'failed to signin')
+
+            return response
+            
+        except User.DoesNotExist:
+            # 가입
+            response = self._get_sign_in_response(access_token, code, 'failed to signup')
+
+            return response
+        
+    def _get_sign_in_response(self, access_token: str, code: str, error_message: str):
+        data = {'access_token': access_token, 'code': code}
+        accept = requests.post(f"{BASE_URL}user/login/finish/", data=data)
+        accept_status = accept.status_code
+        if accept_status != 200:
+            return JsonResponse({'err_msg': error_message}, status=accept_status)
+        accept_json = accept.json()
+
+        refresh_token = accept.headers['Set-Cookie'].split('refresh_token=')[-1].split(';')[0]
+
+        COOKIE_MAX_AGE = 3600 * 24 * 14 # 14 days
+
+        response = {'access_token': accept_json['access']}
+        response_with_cookie = JsonResponse(response)
+        response_with_cookie.set_cookie('refresh_token', refresh_token, max_age=COOKIE_MAX_AGE, httponly=True, samesite='Lax')
+
+        return response_with_cookie
+
+
+class KakaoLoginView(SocialLoginView):
+    adapter_class = kakao_view.KakaoOAuth2Adapter
+    client_class = OAuth2Client
+    callback_url = KAKAO_CALLBACK_URI
+


### PR DESCRIPTION
카카오 API를 이용한 로그인 및 회원 가입 기능 추가

JWT를 이용한 인증/인가 (현재 access token과 refresh token의 기간이 길게 잡혀있음 조정 필요)

**카카오 로그인 기능을 이용하려면 DB social_application 테이블에 정보 추가 필수**

### API
* /user/login/
* /user/login/finish/
* /user/logout/
* /user/token/refresh/

### 변경 사항
* settings.py
  * default permission AllowAny -> IsAuthenticated
* user/models.py
  * User model nickname null=True
    * nickname은 필수값이지만 라이브러리가 기본 django user 모델에 있는 필드를 우선 저장하기 때문에 null=True 옵션 추가, 기본 정보 저장 후 nickname 추가 update
    * 회원 가입 시에 transaction을 걸어 nickname 저장에 실패하는 경우 회원 가입이 되지 않음(=닉네임 반드시 존재하게 됨)