### PR TITLE
회원가입 시 기본 질문 저장, /user/login/ API response 변경

### DIFF
--- a/santa_myojeong_be/settings.py
+++ b/santa_myojeong_be/settings.py
@@ -199,3 +199,21 @@ kakao_secrets = secrets['KAKAO']
 
 KAKAO_REST_API_KEY = kakao_secrets['KAKAO_REST_API_KEY']
 KAKAO_CALLBACK_URI = kakao_secrets['KAKAO_CALLBACK_URI']
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        }
+    },
+    'loggers': {
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    }
+}

--- a/user/adapters.py
+++ b/user/adapters.py
@@ -1,14 +1,25 @@
+import random
+
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.db import transaction
+
+from user.models import DefaultQuestion
 
 
 class KakaoAccountAdapter(DefaultSocialAccountAdapter):
     def save_user(self, request, sociallogin, form=None):
         with transaction.atomic():
+            QUESTION_COUNT = 3
+
             user = super().save_user(request, sociallogin, form)
 
             oauth_data = sociallogin.account.extra_data
             user.nickname = oauth_data['kakao_account']['profile']['nickname']
+
+            question_list = list(DefaultQuestion.objects.filter(is_delete=False))
+            for i, q in enumerate(random.sample(question_list, QUESTION_COUNT)):
+                setattr(user, f'question{i + 1}', q.question)
+
             user.save()
 
         return user

--- a/user/admin.py
+++ b/user/admin.py
@@ -4,3 +4,4 @@ from user import models
 
 admin.site.register(models.User)
 admin.site.register(models.UserLike)
+admin.site.register(models.DefaultQuestion)

--- a/user/models.py
+++ b/user/models.py
@@ -64,3 +64,11 @@ class UserLike(models.Model):
     user = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
     target_user = models.ForeignKey(User, related_name='target_user', on_delete=models.CASCADE)
     created_at = models.DateField(auto_now_add=True)
+
+
+class DefaultQuestion(models.Model):
+    question = models.CharField(max_length=100)
+    is_delete = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.question

--- a/user/models.py
+++ b/user/models.py
@@ -51,6 +51,10 @@ class User(AbstractUser):
     view_count = models.PositiveIntegerField(default=0)
     rabbit = models.IntegerField(choices=RABBITS, default=1)
 
+    question1 = models.CharField(null=True, max_length=100)
+    question2 = models.CharField(null=True, max_length=100)
+    question3 = models.CharField(null=True, max_length=100)
+
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []
 

--- a/user/views.py
+++ b/user/views.py
@@ -64,29 +64,32 @@ class UserAuthView(APIView):
                 return JsonResponse({'err_msg': 'no matching social type'}, status=status.HTTP_400_BAD_REQUEST)
             
             # 기존에 Kakao 가입된 유저
-            response = self._get_sign_in_response(access_token, code, 'failed to signin')
+            response = self._get_sign_in_response(access_token, code, False)
 
             return response
             
         except User.DoesNotExist:
             # 가입
-            response = self._get_sign_in_response(access_token, code, 'failed to signup')
+            response = self._get_sign_in_response(access_token, code, True)
 
             return response
         
-    def _get_sign_in_response(self, access_token: str, code: str, error_message: str):
+    def _get_sign_in_response(self, access_token: str, code: str, is_signup: bool):
         data = {'access_token': access_token, 'code': code}
         accept = requests.post(f"{BASE_URL}user/login/finish/", data=data)
         accept_status = accept.status_code
         if accept_status != 200:
-            return JsonResponse({'err_msg': error_message}, status=accept_status)
+            return JsonResponse({'err_msg': f"failed to {'signup' if is_signup else 'signin'}"}, status=accept_status)
         accept_json = accept.json()
 
         refresh_token = accept.headers['Set-Cookie'].split('refresh_token=')[-1].split(';')[0]
 
         COOKIE_MAX_AGE = 3600 * 24 * 14 # 14 days
 
-        response = {'access_token': accept_json['access']}
+        response = {
+            'access_token': accept_json['access'],
+            'is_signup': is_signup
+        }
         response_with_cookie = JsonResponse(response)
         response_with_cookie.set_cookie('refresh_token', refresh_token, max_age=COOKIE_MAX_AGE, httponly=True, samesite='Lax')
 
@@ -97,4 +100,3 @@ class KakaoLoginView(SocialLoginView):
     adapter_class = kakao_view.KakaoOAuth2Adapter
     client_class = OAuth2Client
     callback_url = KAKAO_CALLBACK_URI
-


### PR DESCRIPTION
회원가입 시 기본적으로 질문 세개가 랜덤하게 저장되는 기능 추가

`/user/login/` API의 response 변경

### 변경 사항
* user/models.py
  * User model: question1, question2, question3 column 추가
  * DefaultQuestion model 추가: 기본 질문 모델
* user/adapters.py
  * 회원가입 할 때 기본 질문 중 랜덤한 3개 저장하는 로직 추가
* user/views.py
  * `/user/login/` API response 변경: `is_signup (bool)` 추가
    * 회원가입 진행 여부
    * 회원가입 했으면 true, 로그인만 했으면 false